### PR TITLE
 on Result page, if user is applying filter, reset page to first page

### DIFF
--- a/app/components/results/GroupByTests.tsx
+++ b/app/components/results/GroupByTests.tsx
@@ -141,6 +141,19 @@ const GroupByTests = () => {
     )
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [resultsPageSize, resultsCurrentPage, statusFilter, sortBy, sortDirection])
+
+  useEffect(() => {
+    navigate(
+      `?sortBy=${sortBy}&sort=${sortDirection}&page=${1}&limit=${resultsPageSize}&status=${statusFilter}`
+    )
+    setStatusFilter(statusFilter)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [statusFilter])
+
+  useEffect(() => {
+    setResultsCurrentPage(candidateTestData.resultsCurrentPage)
+  }, [candidateTestData.resultsCurrentPage])
+
   return (
     <div
       className="flex h-full flex-col gap-6 p-1"


### PR DESCRIPTION
After applying a filter, pagination now getting reset
![reset filter](https://user-images.githubusercontent.com/107034412/214554049-e792a679-eb6f-442e-92b7-00f37b2dcc50.gif)
