### PR TITLE
fix: candidate result for text type question

### DIFF
--- a/app/components/results/ResultDetailsQuestionsPreview.tsx
+++ b/app/components/results/ResultDetailsQuestionsPreview.tsx
@@ -72,6 +72,7 @@ const ResultDetailsQuestionsPreview = ({
     correctAnswers: any
   ) => {
     if (questionType === QuestionTypes.text) {
+      answers.length === 0 && setCorrectAnswer(false)
       answers.forEach((value, index) => {
         if (value !== correctAnswers[index].answer) {
           setCorrectAnswer(false)


### PR DESCRIPTION
1. If the Question is text order type and we didn’t answer but click on next then it will be considered as unanswered and In Result Preview it should show as wrong